### PR TITLE
Adjust CNN to number of call types

### DIFF
--- a/giant_otter/cnn-classifier-pipeline.ipynb
+++ b/giant_otter/cnn-classifier-pipeline.ipynb
@@ -1303,7 +1303,7 @@
     "model.add(Flatten())\n",
     "model.add(Dense(512, activation='sigmoid'))\n",
     "model.add(Dropout(rate=0.5))\n",
-    "model.add(Dense(2, activation='softmax'))\n",
+    "model.add(Dense(len(call_labels_list), activation='softmax'))\n",
     "optimizer = Adam(lr=1e-3)\n",
     "\n",
     "model.compile(optimizer = optimizer, \n",

--- a/giant_otter/cnn-classifier-pipeline.ipynb
+++ b/giant_otter/cnn-classifier-pipeline.ipynb
@@ -1465,7 +1465,7 @@
     "    model.add(Flatten())\n",
     "    model.add(Dense(512, activation='sigmoid'))\n",
     "    model.add(Dropout(rate=0.5))\n",
-    "    model.add(Dense(2, activation='softmax'))\n",
+    "    model.add(Dense(len(call_labels_list), activation='softmax'))\n",
     "    optimizer = Adam(lr=learning_rate)\n",
     "\n",
     "    model.compile(optimizer = optimizer, \n",


### PR DESCRIPTION
Adjust CNN's classification categories to the number of call types used.
Currently, when playing with the tutorial, if more call types are used in `call_label_list`, error occurs due to difference in CNN output layer and call types.